### PR TITLE
Beschreibung der Funktionalität von /dba/cryptPWs

### DIFF
--- a/exercices.md
+++ b/exercices.md
@@ -210,11 +210,11 @@ Zeichne das Entity-Relationship-Modell deines InstaHubs.
 
 Bereits vor deinem ersten Login in deinem InstaHub haben sich 203 User registriert!
 
-Fügst du über einen SQL-Befehl einen neuen User hinzu, kann sich dieser nicht einloggen, da das Passwort gesichert in der Datenbank abgespeichert werden muss und nicht im Klartext verglichen werden kann.
+Fügst du über einen SQL-Befehl einen neuen User hinzu, kann sich dieser nicht einloggen. Wenn der User versucht sich einzuloggen, dann wird von dem eingegebenen Passwort ein sogenannter Hashwert berechnet. Wenn dieser Wert mit dem in der Datenbank hinterlegten Wert übereinstimmt, wird der User eingeloggt. Wenn du das Passwort in der Datenbank im Klartext speicherst, schlägt der Login-Prozess also fehl.
 
-Um Passwörter im Klartext zu hashen, kannst du in deinem Browser die folgende Adresse aufrufen:
+Um alle Passwörter, die im Klartext gespeichert sind, durch ihren Hashwert zu ersetzen, kannst du in deinem Browser die folgende Adresse aufrufen:
 
-[https://*hub*.instahub.org/dba/cryptPWs](#)
+`https://<hub>.instahub.org/dba/cryptPWs`
 
 w> Im Folgenden wird davon ausgegangen, dass noch alle User mit der `id` 1 bis 203 vorhanden sind. Ist dem nicht so, können die vorbereiteten Datensätze nicht eingefügt werden. Am besten erstellst du einfach die fehlenden Nutzer neu und weist denen anschließend per SQL eine passende `id` zu. Notfalls kann dein/e LehrerIn den Import auch erzwingen.
 


### PR DESCRIPTION
Die Beschreibung der Funktionalität des Endpunktes /dba/cryptPWs war (für mich) unklar. Beschreibung wurde präzisiert.

Nachrangige Änderungen: 
Erweiterte Erläuterung, warum Login nach manuellem Einfügen eines Nutzers zunächst nicht klappt.
In der URL des Endpunkts muss der Name des Hubs ersetzt werden, deshalb ist ein klickbarer Link (meiner Meinung nach) nicht hilfreich.